### PR TITLE
Add `allowedCssProperties` prop

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   },
   "homepage": "https://github.com/mat-sz/vue-letter",
   "dependencies": {
-    "lettersanitizer": "^1.0.5"
+    "lettersanitizer": "^1.0.6"
   },
   "author": "Mat Sz <contact@matsz.dev>",
   "license": "BSD-3-Clause-Clear",

--- a/src/Letter.vue
+++ b/src/Letter.vue
@@ -10,6 +10,7 @@ interface Props {
   iframeTitle: string;
   rewriteExternalLinks: (url: string) => string;
   rewriteExternalResources: (url: string) => string;
+  allowedCssProperties: string[];
   allowedSchemas: string[];
   preserveCssPriority: boolean;
 }
@@ -25,6 +26,7 @@ const {
   rewriteExternalLinks,
   rewriteExternalResources,
   allowedSchemas,
+  allowedCssProperties,
   preserveCssPriority,
 } = reactive(props);
 
@@ -33,6 +35,7 @@ const sanitizerOptions = {
   rewriteExternalLinks,
   allowedSchemas,
   preserveCssPriority,
+  allowedCssProperties,
 };
 
 const sanitizedHtml = sanitize(html, text, sanitizerOptions);

--- a/yarn.lock
+++ b/yarn.lock
@@ -704,7 +704,7 @@ kolorist@^1.8.0:
   resolved "https://registry.yarnpkg.com/kolorist/-/kolorist-1.8.0.tgz#edddbbbc7894bc13302cdf740af6374d4a04743c"
   integrity sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==
 
-lettersanitizer@^1.0.5:
+lettersanitizer@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/lettersanitizer/-/lettersanitizer-1.0.6.tgz#d56df4c150bfe2a7edd9c6c5ce99f23aba2a23e4"
   integrity sha512-2vj0tUtBRjlmTCFsgVlFmfi04p049Zwv/4eBGWBUOKropEoL+q+jTQQfFyDu50j7gL76pycMvrqD0uV0vxX2zg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -705,9 +705,9 @@ kolorist@^1.8.0:
   integrity sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==
 
 lettersanitizer@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/lettersanitizer/-/lettersanitizer-1.0.5.tgz#6ca7dc5688f199793f12aa599c34a4cea5b61378"
-  integrity sha512-OEJjdlRE96uKB0VfMi4nb3hBctYl1Ss6DQg9SPXRpGcjaBjcmDaibp0ZIdQu1TPwMAEvWC8xRqIcTAooElSDIg==
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/lettersanitizer/-/lettersanitizer-1.0.6.tgz#d56df4c150bfe2a7edd9c6c5ce99f23aba2a23e4"
+  integrity sha512-2vj0tUtBRjlmTCFsgVlFmfi04p049Zwv/4eBGWBUOKropEoL+q+jTQQfFyDu50j7gL76pycMvrqD0uV0vxX2zg==
 
 lilconfig@2.1.0:
   version "2.1.0"


### PR DESCRIPTION
A recent change (https://github.com/mat-sz/lettersanitizer/pull/9) added the ability to allow certain CSS properties to the underlying `lettersanitizer` package. 

This PR exposes the said option via props to the component